### PR TITLE
Proposal: Adjust Leveled List Adding Behavior & chance field

### DIFF
--- a/include/containerManager.h
+++ b/include/containerManager.h
@@ -48,6 +48,7 @@ namespace ContainerManager {
 
 	struct SwapRule {
 		int                                                             count               { 1 };
+		unsigned int													chance				{ 100 };
 		bool                                                            allowVendors        { false };
 		bool                                                            onlyVendors         { false };
 		bool                                                            bypassSafeEdits     { false };

--- a/src/containerManager.cpp
+++ b/src/containerManager.cpp
@@ -367,6 +367,10 @@ namespace ContainerManager {
 				_loggerInfo("        >Global: {}, Value: {}", pair.first->GetFormEditorID(), pair.second);
 			}
 		}
+		if (a_rule.chance != 0) {
+			_loggerInfo("");
+			_loggerInfo("    This rule has a {}% chance to trigger (for each valid container).", a_rule.chance);
+		}
 		if (a_rule.randomAdd) {
 			_loggerInfo("");
 			_loggerInfo("    This rule will randomly add a random item in the add field.");
@@ -473,6 +477,18 @@ namespace ContainerManager {
 			if (!merchantContainer && rule.onlyVendors) continue;
 			if (!rule.bypassSafeEdits && isContainerUnsafe) continue;
 			if (!IsRuleValid(&rule, a_ref)) continue;
+
+			/* proposed behavior of "chance" in replace rules:
+				if random fails, do NOT replace			
+
+				(can also be set to: ignore "chance" field
+				if a rule is replacer rule)
+			 */
+			if (rule.chance != 100) {
+				auto random = clib_util::RNG().generate<short>(0, 100);
+				if (random > rule.chance) continue;
+			}
+
 
 			if (rule.removeKeywords.empty()) {
 				auto itemCount = a_ref->GetInventoryCounts()[rule.oldForm];
@@ -601,6 +617,15 @@ namespace ContainerManager {
 			if (rule.count < 1) {
 				ruleCount = 1;
 			}
+
+			/*	proposed behavior of "chance" in add rules:
+				if random fails, do not add
+			*/
+			if (rule.chance != 100) {
+				auto random = clib_util::RNG().generate<short>(0, 100);
+				if (random > rule.chance) continue;
+			}
+
 
 			if (rule.randomAdd) {
 				size_t index = clib_util::RNG().generate<size_t>(0, rule.newForm.size() - 1);

--- a/src/containerManager.cpp
+++ b/src/containerManager.cpp
@@ -4,14 +4,70 @@
 
 namespace {
 	static void AddLeveledListToContainer(RE::TESLeveledList* list, RE::TESObjectREFR* a_container, uint32_t a_count) {
+
+		auto chanceNone = list->chanceNone;
+		if (chanceNone >= 100) return;	   // no one would ever set a LL's chanceNone to 100, would they? But if yes, our work is done here
+
+
+		/*
+			AFAIK, CalculateCurrentFormList() (which is called in Utility::ResolveLeveledList() later)
+			only returns a list of items that *can* be selected given player's current level etc.
+
+			i.e. it does not calculate ChanceNone
+			so we may have to imitate that calc here
+		*/
+		auto random = clib_util::RNG().generate<short>(0, 100);
+		if (random < chanceNone) return;
+
+
+
 		RE::BSScrapArray<RE::CALCED_OBJECT> result{};
 		Utility::ResolveLeveledList(list, &result, a_count);
 		if (result.size() < 1) return;
+		
+
+		/*
+			The code below is meant to simply pick an item then add to container
+
+			we *could* just generate a random index then fetch the item
+			but the ThingToAdd could be null
+
+			workaround: shuffle the whole thing
+			then go from begin to end, get the first that is valid
+
+			there may be less compute heavy ways?
+		*/				
+
+
+		/*
+			The lambda func below is entirely because I could not get this
+				std::shuffle(result.begin(), result.end(), std::default_random_engine(...));
+			to work. If can get it to work, would no longer need the lambda.
+		*/
+		constexpr auto ShuffleResult = [&](RE::BSScrapArray<RE::CALCED_OBJECT> arr, auto seed) {
+			int startIdx = 0;
+			int endIdx = arr.size();
+
+			if (endIdx <= 1) return;	// obviously
+
+			for (int i = endIdx - 1; i > 0; --i) {
+				std::uniform_int_distribution<int> d(startIdx, i);
+				std::swap(arr[i], arr[d(seed)]);
+			}
+			
+		};
+
+		ShuffleResult(result, std::default_random_engine( (unsigned int) std::chrono::steady_clock::now().time_since_epoch().count()  ));
+
+
 
 		for (auto& obj : result) {
 			auto* thingToAdd = static_cast<RE::TESBoundObject*>(obj.form);
+			
 			if (!thingToAdd) continue;
 			a_container->AddObjectToContainer(thingToAdd, nullptr, obj.count, nullptr);
+
+			return; // one item in, we done
 		}
 	}
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -681,6 +681,7 @@ namespace Settings {
 				auto& oldId = change["remove"];
 				auto& newId = change["add"];
 				auto& countField = change["count"];
+				auto& chanceField = change["chance"];
 				auto& removeKeywords = change["removeByKeywords"];
 				if (!(oldId || newId || removeKeywords)) {
 					a_report->hasBatData = true;
@@ -766,6 +767,16 @@ namespace Settings {
 				}
 				else {
 					newRule.count = -1;
+				}
+
+
+				if (chanceField && chanceField.isUInt()) {
+					newRule.chance = (uint8_t) std::min((int) chanceField.asUInt(), 100); // if user entered a number higher than 100, default to 100
+
+					if (newRule.chance == 0) newRule.chance = 100; // proposed default behavior: do NOT allow chance to ever be 0, default = 100
+				}
+				else {
+					newRule.chance = 100;	// proposed default behavior: do NOT allow chance to be negative, default = 100
 				}
 
 				ContainerManager::ContainerManager::GetSingleton()->CreateSwapRule(newRule);


### PR DESCRIPTION
**(The changes are quite small & I am much more careful this time, but please still check if anything wrong, e.g. due to different CLib forks having different ways to name things)**

---

1. Leveled List behavior

As of 2.2.1, it seems that when adding something that is a leveled list (LL), _everything_ in that list (that satisfies player level requirement) gets added:

```cpp
		RE::BSScrapArray<RE::CALCED_OBJECT> result{};
		Utility::ResolveLeveledList(list, &result, a_count);
		if (result.size() < 1) return;

		for (auto& obj : result) {
			auto* thingToAdd = static_cast<RE::TESBoundObject*>(obj.form);
			if (!thingToAdd) continue;
			a_container->AddObjectToContainer(thingToAdd, nullptr, obj.count, nullptr);
		}
```

IMO this kinda defeats the point of a LL (taking only one item out of a list of items).

If allowed, this PR changes that behavior, such that only one item from a LL gets added.

There is also a "chanceNone" setting in LL, that determines if nothing appears at all, also added.

(Already tested in game & working so far)



2. "chance" field

This is for if we want to _not_ always trigger a rule to add stuff to container.
(e.g. if we want to control loot rarity)

Intended json format:

```json

                {
                    "add": [
                        "LItemFurnitureMiscItems75",
                        "LootFalmerOre10",
                        "LootBanditGems10",
                        "LItemFurnitureNobleClothing"
                    ],
                    "randomAdd": true,
                    "count": 1000,

                    "chance" : 50
                }

```

If not defined or ill-defined, default value is 100 (always)